### PR TITLE
修复删除节点后孩子节点扔参与递归比较

### DIFF
--- a/src/virtual-dom/patch.js
+++ b/src/virtual-dom/patch.js
@@ -27,6 +27,12 @@ patch.prototype = {
             this.applyPatch(node, patch);
             this.patchesRemaining--;
         }
+
+        if (node.replaceComplete) {
+            delete node.replaceComplete;
+            return;
+        }
+
         if (this.patchesRemaining > 0 && (node === this.root[0] || node && node.nodeType === 1 && !$.data(node, 'widget'))) {
             var childNodes = node.childNodes;
             for (var i = 0, len = childNodes.length ; i < len ; i++) {
@@ -106,6 +112,7 @@ patch.prototype = {
         var newNode = vdom.render(this.widget)[0];
         node.parentNode.insertBefore(newNode, node);
         node.parentNode.removeChild(node);
+        node.replaceComplete = true;
     }
 };
 

--- a/src/virtual-dom/patch.js
+++ b/src/virtual-dom/patch.js
@@ -28,12 +28,9 @@ patch.prototype = {
             this.patchesRemaining--;
         }
 
-        if (node.replaceComplete) {
-            delete node.replaceComplete;
-            return;
-        }
-
-        if (this.patchesRemaining > 0 && (node === this.root[0] || node && node.nodeType === 1 && !$.data(node, 'widget'))) {
+        if (this.patchesRemaining > 0
+            && (node === this.root[0] || node && node.nodeType === 1 && !node.isDetached && !$.data(node, 'widget'))
+        ) {
             var childNodes = node.childNodes;
             for (var i = 0, len = childNodes.length ; i < len ; i++) {
                 if (this.walk(childNodes[i])) {
@@ -112,7 +109,7 @@ patch.prototype = {
         var newNode = vdom.render(this.widget)[0];
         node.parentNode.insertBefore(newNode, node);
         node.parentNode.removeChild(node);
-        node.replaceComplete = true;
+        node.isDetached = true;
     }
 };
 


### PR DESCRIPTION
对于这样的diff
oldTree:

```
<div>
    <div class="panel-wrapper>
        <div class="path"></div>
    </div>
    <div class="panel-wrapper>
        <div class="path"></div>
    </div>
</div>
```

newTree

```
<div>
    <span class="edit">
    </span>
    <label><label>
</div>
```

在diff第一个panel-wrapper时，你在domTree中删除了该节点，但该节点仍有childNodes,因此下一步的patch.walk方法中，this.patches记录的是label节点，而node传入的是panel-wrapper的孩子结点path。造成diff出错。
